### PR TITLE
Add some console logs in UploadImage.jsx to attempt to troubleshoot cloudinary image uploading error; change the post route to a relative path, /api/upload, to see if it helps.

### DIFF
--- a/client/src/components/UploadImage/UploadImage.jsx
+++ b/client/src/components/UploadImage/UploadImage.jsx
@@ -22,12 +22,17 @@ const UploadImage = ({ setImageUrl }) => {
 
         setUploading(true);
 
+        console.log('this is your formData from inside function handleUpload:')
+        console.log(formData);
+
         try {
-            const response = await axios.post('http://localhost:3001/api/upload', formData, {
+            const response = await axios.post('/api/upload', formData, {
                 headers: {
                     'Content-Type': 'multipart/form-data',
                 },
             });
+            console.log('this is your response variable from awaiting the axios.post in function handleUpload.')
+            console.log(response);
 
             setImageUrl(response.data.url);
             setUploading(false);


### PR DESCRIPTION
Add some console logs in UploadImage.jsx to attempt to troubleshoot cloudinary image uploading error; change the post route to a relative path, /api/upload, to see if it helps.