### PR TITLE
CreateStory: remove all choices when "ends story" checkbox is checked and add close btns to modals; StoryIndex: change styling so layout is optimized for every viewport width; see full description

### DIFF
--- a/client/src/components/CreateStory/CreateStory.css
+++ b/client/src/components/CreateStory/CreateStory.css
@@ -160,11 +160,27 @@
 }
 
 .close-button {
-  background: none;
-  border: none;
-  color: #fff;
-  /* White color */
+  font-size: 2rem;
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: 2rem;
+  height: 2rem;
+  color: #A94E6F;
   cursor: pointer;
+}
+
+.close-button::before {
+  content: '×';
+  font-size: 2rem;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.close-button:hover {
+  color: #BD85B2;
 }
 
 .editor-content {
@@ -224,11 +240,9 @@
   text-align: center;
   transition: background-color ease-in-out 0.5s;
   padding: 5px 10px;
-  /* margin: 10px 0px 10px 0px; */
   margin-bottom: 20px;
   margin-top: -5px;
   min-width: 113px;
-  /* min-height: 42.4px; */
 }
 
 .add-choice-button {
@@ -376,8 +390,6 @@ button.save-button:hover {
   margin-left: 200px;
 }
 
-/* Add more indentation levels as needed */
-
 /* Form elements with flexbox for better alignment */
 form label,
 form input,
@@ -386,9 +398,6 @@ form select {
   display: block;
   width: 100%;
   margin: 0px;
-  /* padding: 0px; */
-  /* margin-bottom: 10px; */
-  /* margin: 10px 0px; */
 }
 
 form .form-group {
@@ -458,6 +467,11 @@ textarea#chapterContent
 
   .editor-header {
     padding: 5px;
+  }
+
+  .close-button {
+    top: 10px;
+    right: 10px;
   }
 
   .editor-content {

--- a/client/src/components/CreateStory/CreateStory.jsx
+++ b/client/src/components/CreateStory/CreateStory.jsx
@@ -79,7 +79,8 @@ function CreateStory() {
     if (currentChapter.choices.length < 3) {
       setCurrentChapter(prevState => ({
         ...prevState,
-        choices: [...prevState.choices, { choiceText: '', nextChapterIndex: null }]
+        choices: [...prevState.choices, { choiceText: '', nextChapterIndex: null }],
+        isEnd: false // Automatically unmark as end if a choice is added
       }));
     } else {
       alert('You can only add up to three choices.');
@@ -293,11 +294,25 @@ function CreateStory() {
       {/* Modal for adding or editing a chapter */}
       <Modal
         isOpen={isChapterModalOpen}
-        onRequestClose={() => setIsChapterModalOpen(false)}
-        className='modal'
-        overlayClassName='overlay'
+        onRequestClose={() => {
+          // Reset the current chapter and close the modal
+          setCurrentChapter({ title: '', content: '', isEnd: false, choices: [{ choiceText: '', nextChapterIndex: null }] });
+          setIsChapterModalOpen(false);
+        }}
+        className="modal"
+        overlayClassName="overlay"
       >
-        <h2>{chapterIndexToEdit !== null ? 'Edit Chapter' : 'Add New Chapter'}</h2>
+        <div className="modal-header">
+          <h2>{chapterIndexToEdit !== null ? 'Edit Chapter' : 'Add New Chapter'}</h2>
+          <button
+            className="close-button"
+            onClick={() => {
+              setCurrentChapter({ title: '', content: '', isEnd: false, choices: [{ choiceText: '', nextChapterIndex: null }] });
+              setIsChapterModalOpen(false);
+            }}
+          >
+          </button>
+        </div>
         <form onSubmit={handleChapterSubmit}>
           <label htmlFor='chapterTitle'>Title:</label>
           <input type='text' id='chapterTitle' value={currentChapter.title} onChange={(e) => handleChapterChange('title', e.target.value)} required />
@@ -308,7 +323,16 @@ function CreateStory() {
             <input
               type='checkbox'
               checked={currentChapter.isEnd}
-              onChange={(e) => handleChapterChange('isEnd', e.target.checked)}
+              onChange={(e) => {
+                handleChapterChange('isEnd', e.target.checked);
+                if (e.target.checked) {
+                  // Clear all choices at once when the "Ends Story" checkbox is checked
+                  setCurrentChapter(prevState => ({
+                    ...prevState,
+                    choices: [] // Reset the choices array to empty
+                  }));
+                }
+              }}
             />
           </label>
 
@@ -333,11 +357,25 @@ function CreateStory() {
       {/* Modal for adding a new chapter for a specific choice */}
       <Modal
         isOpen={isChoiceModalOpen}
-        onRequestClose={() => setIsChoiceModalOpen(false)}
-        className='modal'
-        overlayClassName='overlay'
+        onRequestClose={() => {
+          // Reset the current chapter and close the modal
+          setCurrentChapter({ title: '', content: '', isEnd: false, choices: [{ choiceText: '', nextChapterIndex: null }] });
+          setIsChoiceModalOpen(false);
+        }}
+        className="modal"
+        overlayClassName="overlay"
       >
-        <h2>Add New Chapter for Choice</h2>
+        <div className="modal-header">
+          <h2>Add New Chapter for Choice</h2>
+          <button
+            className="close-button"
+            onClick={() => {
+              setCurrentChapter({ title: '', content: '', isEnd: false, choices: [{ choiceText: '', nextChapterIndex: null }] });
+              setIsChoiceModalOpen(false);
+            }}
+          >
+          </button>
+        </div>
         <form onSubmit={handleChoiceSubmit}>
           <label htmlFor='chapterTitle'>Title:</label>
           <input type='text' id='chapterTitle' value={currentChapter.title} onChange={(e) => handleChapterChange('title', e.target.value)} required />
@@ -348,7 +386,16 @@ function CreateStory() {
             <input
               type='checkbox'
               checked={currentChapter.isEnd}
-              onChange={(e) => handleChapterChange('isEnd', e.target.checked)}
+              onChange={(e) => {
+                handleChapterChange('isEnd', e.target.checked);
+                if (e.target.checked) {
+                  // Clear all choices at once when the "Ends Story" checkbox is checked
+                  setCurrentChapter(prevState => ({
+                    ...prevState,
+                    choices: [] // Reset the choices array to empty
+                  }));
+                }
+              }}
             />
           </label>
 

--- a/client/src/components/StoryIndex/StoryIndex.css
+++ b/client/src/components/StoryIndex/StoryIndex.css
@@ -1,9 +1,9 @@
-/* General Styles */
+/* Selectors are listed in the order they appear in the jsx. Unless a class includes 'desktop' or 'mobile' in its name, its element will appear regardless of viewport width. */
+
 .mythweaver {
   text-align: center;
   background-color: var(--bg-color);
   min-height: 100vh;
-  /* Ensures content fits */
 }
 
 /* Used to help properly fit page elements if loading or error */
@@ -20,27 +20,58 @@
 .story-index {
   font-family: 'Comic Sans MS', cursive, sans-serif;
   min-height: calc(100vh - var(--header-height));
-  padding: 20px;
   box-sizing: border-box;
+  padding: 40px;
 }
 
 .story-main-content {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: auto;
+  display: flex;
+  flex-direction: row;
   gap: 10px;
-  background-color: var(--bg-color);
-  padding: 20px;
   max-width: 80vw;
+  height: fit-content;
   margin: auto;
 }
 
+.accessory-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+  margin: 0;
+  padding: 0;
+}
+
+.story-photo-wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.title-wrapper-mobile {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 10px 10px 0px 0px;
+  box-sizing: border-box;
+  z-index: 2;
+  padding: 10px;
+  margin: 0;
+}
+
+.title-wrapper-mobile .title-text-mobile {
+  color: white;
+  font-size: 24px;
+  margin: 0;
+}
+
 .story-photo {
-  grid-area: 1 / 1 / 3 / 2;
+  display: flex;
   background-color: var(--text-color);
   text-align: center;
   border-radius: var(--border-radius);
-  margin: auto;
+  margin: 0;
 }
 
 .story-photo img {
@@ -50,65 +81,79 @@
   background-size: contain;
 }
 
-.rating {
-  grid-area: 3 / 1 / 4 / 2;
+.rating-desktop {
   display: flex;
+  width: 100%;
+  height: fit-content;
   flex-direction: column;
   justify-content: center;
   align-content: center;
   align-items: center;
   align-self: center;
-  padding: 5px;
   background-color: var(--rating-bg);
   border-radius: var(--border-radius);
-  height: fit-content;
-  margin: auto;
+  padding-bottom: 5px;
+  margin: 0;
 }
 
-p.rating {
-  padding: 0px;
+.rating-desktop .no-ratings-message-desktop {
+  width: 100%;
+  padding: 10px 0px 5px 0px;
 }
 
-.star {
+.rating-container-desktop {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+}
+
+.star-desktop {
   color: #ffcc00;
   font-size: 2rem;
+  padding: 0;
+  margin: 0;
 }
 
-.genre-tags-links {
-  grid-area: 4 / 1 / 5 / 2;
+.genre-tags-desktop {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: fit-content;
   background-color: var(--dk-container-color);
+  text-align: center;
+  align-content: center;
+  justify-content: center;
+  gap: 10px;
+  align-self: start;
+  border-radius: var(--border-radius);
   padding: 10px;
+}
+
+.tbr-button-container-desktop {
+  display: flex;
+  width: 100%;
   height: fit-content;
   text-align: center;
   align-content: center;
-  align-self: start;
   border-radius: var(--border-radius);
-}
-
-.tbr-button-container {
-  grid-area: 5 / 1 / 6 / 2;
   padding: 0px;
-  height: fit-content;
-  text-align: center;
-  align-content: center;
-  align-self: start;
-  border-radius: var(--border-radius);
+  margin: 0px;
 }
 
-.tbr-button {
+.tbr-button-desktop {
   background-color: var(--story-4);
   color: var(--accent-container);
-  padding: 10px 20px;
   width: 100%;
-  margin: 0;
-  align-self: flex-end;
+  height: 100%;
   border: none;
-  height: fit-content;
   border-radius: var(--border-radius);
   font-size: 18px;
   cursor: pointer;
   text-align: center;
   transition: background-color ease-in-out 0.5s;
+  padding: 10px 20px;
+  margin: 0;
 }
 
 .tbr-button:hover {
@@ -116,85 +161,224 @@ p.rating {
 }
 
 .story-description {
-  grid-area: 1 / 2 / 6 / 5;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 20px;
   background-color: var(--mid-dark-accent);
   color: var(--accent-container);
-  padding: 20px;
   border-radius: var(--border-radius);
   text-align: center;
-  height: fit-content;
+  padding: 40px;
+  margin: 0px auto;
 }
 
-.story-description h2 {
+.story-description .title-desktop {
   color: var(--header-text);
   text-shadow: 1px 1px 2px var(--dark-accent), 0px 0px 2px var(--dark-accent);
-  padding-bottom: 20px;
 }
 
-p.author-detail {
-  margin-bottom: 20px;
+.story-description p,
+.author-and-genre-mobile,
+.no-ratings-message-mobile,
+.rating-mobile p,
+.tags-mobile {
+  font-size: 18px;
+  color: var(--accent-container);
 }
 
-.start-adventure-button {
+.rating-mobile {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  justify-content: center;
+  align-content: center;
+  align-items: center;
+  align-self: center;
+  color: #BAC8CF;
+  margin: -5px 0px 0px 0px;
+}
+
+.rating-mobile .no-ratings-message-mobile {
+  width: 100%;
+  padding: 0px;
+}
+
+.rating-container-mobile {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+}
+
+.star-mobile {
+  color: #ffcc00;
+  font-size: 2rem;
+  padding: 0;
+  margin: 0;
+}
+
+button.start-adventure-button {
   background-color: var(--button-accent);
   color: var(--accent-container);
-  padding: 10px 20px;
-  margin: 20px 0;
-  align-self: flex-end;
   border: none;
-  height: fit-content;
   border-radius: var(--border-radius);
   font-size: 18px;
   cursor: pointer;
   text-align: center;
   transition: background-color ease-in-out 0.5s;
+  padding: 10px 20px;
+  width: 260px;
+  text-decoration: none;
 }
 
-.start-adventure-button:hover {
+button.start-adventure-button:hover {
   background-color: var(--dk-button-accent);
 }
 
-/* Media Queries */
-@media (max-width: 768px) {
+button.tbr-button-mobile {
+  background-color: var(--story-4);
+  color: var(--accent-container);
+  width: 260px;  
+  height: fit-content;
+  border: none;
+  border-radius: var(--border-radius);
+  font-size: 18px;
+  cursor: pointer;
+  text-align: center;
+  align-self: center;
+  transition: background-color ease-in-out 0.5s;
+  padding: 10px 20px;
+  margin: 0;
+}
+
+.tbr-button-desktop {
+  background-color: var(--alt-button-accent);
+}
+
+/* Media Queries for responsiveness */
+
+/* For when the vw is 1001px or larger. This is the "desktop" 2-column layout. */
+@media (min-width: 1001px) {
   .story-main-content {
-    grid-template-columns: 1fr 1fr;
-    max-width: 90vw;
+    min-width: 85vw;
   }
 
-  .story-photo {
-    grid-area: 1 / 1 / 2 / 3;
+  .accessory-info {
+    gap: 10px;
   }
 
-  .rating {
-    grid-area: 2 / 1 / 3 / 3;
-    width: 100%;
+  .story-photo-wrapper {
+    min-width: 350px;
+    max-width: 500px;
+    height: auto;
   }
 
-  .genre-tags-links {
-    grid-area: 3 / 1 / 4 / 3;
+  .rating-desktop,
+  .genre-tags-desktop,
+  .tbr-button-container-desktop {
+    flex-grow: 1;
   }
 
-  .tbr-button-container {
-    grid-area: 4 / 1 / 5 / 3;
+  .rating-mobile,
+  .title-wrapper-mobile,
+  button.tbr-button-mobile, 
+  .author-and-genre-mobile, 
+  .tags-mobile {
+    display: none;
   }
 
-  .story-description {
-    grid-area: 5 / 1 / 6 / 3;
+  .story-description p, p.author-desktop {
+    font-size: 20px !important;
   }
 
-  .start-adventure-button {
-    grid-area: auto;
-    margin: 10px auto 0;
+  button.start-adventure-button {
+    font-size: 20px;
+    width: fit-content;
   }
 }
 
-@media (min-width: 480px) {
-  .rating {
-    max-width: 250px;
+
+/* For when the vw is 1000px or smaller. This is the "mobile" single-column layout. */
+@media (max-width: 1000px) {
+  .story-main-content {
+    flex-direction: column;
   }
 
-  .story-photo {
-    max-height: 300px;
-    max-width: 300px;
+  .rating-desktop, 
+  .genre-tags-desktop, 
+  .tbr-button-container-desktop,
+  .story-description .title-desktop, 
+  p.author-desktop {
+    display: none;
+  }
+
+  .story-main-content .story-description {
+    padding: 30px;
+    gap: 30px;
+  }
+}
+
+/* For when the vw is 780px or larger. This helps the photo from becoming too large and ensures the .title-text-mobile is large enough. */
+@media (min-width: 780px) {
+  .title-text-mobile {
+    font-size: 28px;
+  }
+
+  .story-main-content {
+    max-width: 60vw;
+  }
+
+  .story-description p,
+  .author-and-genre-mobile,
+  .no-ratings-message-mobile,
+  .rating-mobile p,
+  .tags-mobile {
+    font-size: 18px;
+  }
+}
+
+/* For when the vw is 700px or smaller */
+@media (max-width: 700px) {
+  button.start-adventure-button {
+    width: 100%;
+  }
+
+  button.tbr-button-mobile {
+    width: 100%;
+  }
+}
+
+/* For when the vw is 600px or smaller */
+@media (max-width: 600px) {
+  .title-text-mobile {
+    font-size: 20px !important;
+  }
+
+  .story-description p, 
+  .author-and-genre-mobile, 
+  .no-ratings-message-mobile, 
+  .rating-mobile p, 
+  .tags-mobile {
+    font-size: 16px !important;
+  }
+
+  button.start-adventure-button {
+    font-size: 18px;
+  }
+}
+
+/* For when the vw is 480px or smaller */
+@media (max-width: 480px) {
+  .title-text-mobile {
+    font-size: 18px !important;
+  }
+
+  .story-description p {
+    font-size: 16px;
+  }
+
+  button.start-adventure-button {
+    font-size: 18px;
   }
 }

--- a/client/src/components/StoryIndex/StoryIndex.jsx
+++ b/client/src/components/StoryIndex/StoryIndex.jsx
@@ -118,59 +118,107 @@ const StoryIndex = () => {
     );
   }
 
-  // Render the story details.
+  // Render the story details. 
   return (
     <div className='mythweaver'>
       <div className='story-index'>
         <main className='story-main-content'>
-          <div className='story-photo'>
-            <img src={story.imageUrl} alt={story.title} />
-          </div>
+          <div className='accessory-info'>
 
-          <div className='rating'>
-            {/* If there are no reviews, so no ratings, display the No Ratings message. */}
-            {story?.reviews?.length === 0 || !story?.reviews ? (
-              <p>No ratings yet!</p>
-            ) : (
-              // If there are ratings, render stars and a message explaining the average rating.
-              <>
-                <div className='display-star-rating star'>
-                    {renderStars(story.averageRating)}
+            <div className='story-photo-wrapper'>
+              {/* On mobile view, this div.title-wrapper-mobile displays the title on a transparent background on top of the photo. */}
+              <div className='title-wrapper-mobile'>
+                <p className='title-text-mobile'>{story.title}</p>
+              </div>
+              <div className='story-photo'>
+                <img src={story.imageUrl} alt={story.title} />
+              </div>
+            </div>
+
+            {/* Start of rating container which only appears here on the desktop view */}
+            <div className='rating-desktop'>
+              {/* If there are no reviews, so no ratings, display the No Ratings message. */}
+              {story?.reviews?.length === 0 || !story?.reviews ? (
+                <p className='no-ratings-message-desktop'>No ratings yet. Be the first to rate this story after reading it!</p>
+              ) : (
+                // If there are ratings, render stars and a message explaining the average rating.
+                <div className='rating-container-desktop'>
+                  <div className='star-desktop'>
+                      {renderStars(story.averageRating)}
+                  </div>
+                  <div className='rating-desktop'>
+                    {story.ratingsCount === 1 ? (
+                      <p>Rated {story.averageRating} star{story.averageRating > 1 ? 's' : ''} by 1 person</p>
+                    ) : (
+                      <p>Rated {story.averageRating} stars on average by {story.ratingsCount} people</p>)}
+                  </div>
                 </div>
-                <div className='rating'>
-                  {story.ratingsCount === 1 ? (
-                    <p>Rated {story.averageRating} star{story.averageRating > 1 ? 's' : ''} by 1 person</p>
-                  ) : (
-                    <p>Rated {story.averageRating} stars on average by {story.ratingsCount} people</p>)}
-                </div>
-              </>
+              )}
+            </div>
+            {/* End of rating container which only appears here on the mobile view */}
+
+            {/* On desktop view, genre and tags appear here. */}
+            <div className='genre-tags-desktop'>
+              <div>Genre: {story.genre}</div>
+              <div>Tags: {formatTags(story.tags)}</div>
+            </div>
+
+            {/* If the user is logged in and in desktop view, render a button to add/remove the story to/from the user's TBR list. */}
+            {Auth.loggedIn() && (
+              <div className='tbr-button-container-desktop'>
+                <button className='tbr-button-desktop' onClick={handleToggleTBR}>
+                  {isInTBR ? 'Remove from To Be Read List' : 'Add to To Be Read List'}
+                </button>
+              </div>
             )}
           </div>
 
-          {/* Display genre and tags. */}
-          <div className='genre-tags-links'>
-            <div>Genre: {story.genre}</div>
-            <div>Tags: {formatTags(story.tags)}</div>
-          </div>
-
-          {/* If the user is logged in, render a button to add/remove the story to/from the user's TBR list. */}
-          {Auth.loggedIn() && (
-            <div className='tbr-button-container'>
-              <button className='tbr-button' onClick={handleToggleTBR}>
-                {isInTBR ? 'Remove from To Be Read List' : 'Add to To Be Read List'}
-              </button>
-            </div>
-          )}
-
           {/* Render the story title, author, description, and link/button to start the story. */}
           <div className='story-description'>
-            <h2>{story.title}</h2>
-            <p className='author-detail'>Created by {story.author}</p>
+            <h2 className='title-desktop'>{story.title}</h2>
+            <p className='author-desktop'>Created by {story.author}</p>
             <p>{story.description}</p>
-            <Link to={`/story-path/${story._id}`}>
-              <button className='start-adventure-button'
-              >Start your Adventure Here</button>
-            </Link>
+
+            <div className='author-and-genre-mobile'>Created by {story.author} in MythWeaver's {story.genre} genre.</div>
+
+            {/* Start of rating container which only appears here on the mobile view */}
+            <div className='rating-mobile'>
+              {/* If there are no reviews, so no ratings, display the No Ratings message. */}
+              {story?.reviews?.length === 0 || !story?.reviews ? (
+                <p className='no-ratings-message-mobile'>No ratings yet. Be the first to rate this story after playing through it!</p>
+              ) : (
+                // If there are ratings, render stars and a message explaining the average rating.
+                <div className='rating-container-mobile'>
+                  <div className='star-mobile'>
+                    {renderStars(story.averageRating)}
+                  </div>
+                  <div className='rating-mobile'>
+                    {story.ratingsCount === 1 ? (
+                      <p>Rated {story.averageRating} star{story.averageRating > 1 ? 's' : ''} by 1 person</p>
+                    ) : (
+                      <p>Rated {story.averageRating} stars on average by {story.ratingsCount} people</p>)}
+                  </div>
+                </div>
+              )}
+            </div>
+            {/* End of rating container which only appears here on the mobile view */}
+
+            {/* On mobile view, tags appear here. */}
+            <div className='tags-mobile'>Tags: {formatTags(story.tags)}</div>
+
+              {/* If the user is logged in and in mobile view, render a button to add/remove the story to/from the user's TBR list. */}
+              {Auth.loggedIn() && (
+                  <button className='tbr-button-mobile' onClick={handleToggleTBR}>
+                    {isInTBR ? 'Remove from To Be Read List' : 'Add to To Be Read List'}
+                  </button>
+              )}
+
+              <Link to={`/story-path/${story._id}`}>
+                <button className='start-adventure-button'
+                >Start your Adventure Here</button>
+              </Link>
+
+
           </div>
         </main>
       </div>

--- a/client/src/components/UserProfile/UserProfile.css
+++ b/client/src/components/UserProfile/UserProfile.css
@@ -77,7 +77,7 @@
   max-width: 300px;
   flex: 1 0 250px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  text-align: left;
+  text-align: center;
   padding: 15px;
   margin-bottom: 20px;
   border-radius: var(--border-radius);


### PR DESCRIPTION
Update logic in CreateStory.jsx so that clicking the ends story checkbox removes all of the currently open choices, since end chapters can't have additional choices for the user to continue on with. Also update logic so that adding a choice ensures the ends story checkbox is un-checked and the chapter is no longer considered an end chapter. Also add close buttons to the CreateStory modals with the exception of the initial story details modal. If the user clicks the modal's close button instead of the save button, any data in the currently open modal is disregarded, while the rest of the data remains. In StoryIndex.jsx and StoryIndex.css, change styling with flexbox and different media queries so that elements are aligned and matched in width/height, regardless of viewport width and presence/absence of ratings and TBR button.