### PR TITLE
Fix vertical positioning of 'x' within modal close button

### DIFF
--- a/client/src/components/CreateStory/CreateStory.css
+++ b/client/src/components/CreateStory/CreateStory.css
@@ -375,6 +375,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -54%);
+  height: fit-content;
   color: var(--warm-white);
 }
 

--- a/client/src/components/Header/LoginSignupModal.css
+++ b/client/src/components/Header/LoginSignupModal.css
@@ -69,7 +69,7 @@ div.fade.auth-modal.modal.show {
   /* The below 4 properties center the 'x' inside the modal close button */
   top: 50%;
   left: 50%;
-  transform: translate(-120%, -40%);
+  transform: translate(-120%, -42%);
   height: fit-content;
 }
 


### PR DESCRIPTION
The x within the close button of the create story modals wasn't quite vertically centered; I added height: fit-content under .close-button::before in CreateStory.css which fixed the issue. I also adjusted the vertical positioning of the x within the close button of the login/signup modal.