### PR TITLE
Add extra break to separate each screenshot that is not from the same page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,13 +359,16 @@ We've taken care to build a flexible, responsive design which adapts to differen
 <img src="./assets/624px-create-story-entry-pg.png" alt="624px-create-story-entry-pg" width="624">
 
 <br />
+<br />
 
 <img src="./assets/624px-create-story-modal.png" alt="624px-create-story-modal" width="624">
 
 <br />
+<br />
 
 <img src="./assets/624px-story-path.png" alt="624px-story-path" width="624">
 
+<br />
 <br />
 
 <img src="./assets/624px-user-profile-1.png" alt="624px-user-profile-1" width="624">
@@ -391,11 +394,13 @@ We've taken care to build a flexible, responsive design which adapts to differen
 <img src="./assets/896px-login.png" alt="896px-login" width="896">
 
 <br />
+<br />
 
 <img src="./assets/896px-story-index-1.png" alt="896px-story-index-1" width="896">
 
 <img src="./assets/896px-story-index-2.png" alt="896px-story-index-2" width="896">
 
+<br />
 <br />
 
 <img src="./assets/896px-about-us-contact-us-1.png" alt="896px-about-us-contact-us-1" width="896">
@@ -427,6 +432,7 @@ We've taken care to build a flexible, responsive design which adapts to differen
 <img src="./assets/1232px-create-story-diagram.png" alt="1232px-create-story-diagram" width="1232">
 
 <br />
+<br />
 
 <img src="./assets/1232px-myth-index-1.png" alt="1232px-myth-index-1" width="1232">
 
@@ -434,6 +440,7 @@ We've taken care to build a flexible, responsive design which adapts to differen
 
 <img src="./assets/1232px-myth-index-3.png" alt="1232px-myth-index-3" width="1232">
 
+<br />
 <br />
 
 <img src="./assets/1232px-story-review-1.png" alt="1232px-story-review-1" width="1232">
@@ -455,13 +462,16 @@ We've taken care to build a flexible, responsive design which adapts to differen
 <img src="./assets/1600px-landing.png" alt="1600px-landing" width="1600">
 
 <br />
+<br />
 
 <img src="./assets/1600px-story-index.png" alt="1600px-story-index" width="1600">
 
 <br />
+<br />
 
 <img src="./assets/1600px-story-path.png" alt="1600px-story-path" width="1600">
 
+<br />
 <br />
 
 <img src="./assets/1600px-user-profile-1.png" alt="1600px-user-profile-1" width="1600">


### PR DESCRIPTION
Add extra break to separate each screenshot that is not from the same page. (Quick note that setting a static width on each screenshot img in the README was the way to go; seems to work the most compatibly with Github's README css.)